### PR TITLE
Check if the pawn is too big for the bed.

### DIFF
--- a/Languages/English/Keyed/KB_Go_To_Sleep_Keys.xml
+++ b/Languages/English/Keyed/KB_Go_To_Sleep_Keys.xml
@@ -2,5 +2,6 @@
 <LanguageData>
   <KB_Go_To_Sleep_Cannot_Sleep>Cannot sleep</KB_Go_To_Sleep_Cannot_Sleep>
   <KB_Go_To_Sleep_Not_Tired>not tired enough</KB_Go_To_Sleep_Not_Tired>
+  <KB_Go_To_Sleep_Bed_Too_Small>bed is too small</KB_Go_To_Sleep_Bed_Too_Small>
   <KB_Go_To_Sleep_GoToSleep>Go to sleep</KB_Go_To_Sleep_GoToSleep>
 </LanguageData>

--- a/Source/KB_Go_To_Sleep/FloatMenuMakerMap_Patches.cs
+++ b/Source/KB_Go_To_Sleep/FloatMenuMakerMap_Patches.cs
@@ -25,6 +25,7 @@ namespace KB_Go_To_Sleep
 
                 foreach (LocalTargetInfo bed in GenUI.TargetsAt(clickPos, ForSleeping(pawn), thingsOnly: true))
                 {
+                    Building_Bed bedBuilding = bed.HasThing ? bed.Thing as Building_Bed : null;
                     if (pawn.needs.rest.CurLevel > FloatMenuMakerMap_AddHumanlikeOrders.FallAsleepMaxLevel(pawn))
                     {
                         opts.Add(new FloatMenuOption("KB_Go_To_Sleep_Cannot_Sleep".Translate() + ": " + "KB_Go_To_Sleep_Not_Tired".Translate().CapitalizeFirst(), null));
@@ -32,6 +33,10 @@ namespace KB_Go_To_Sleep
                     else if (!pawn.CanReach(bed, PathEndMode.OnCell, Danger.Deadly))
                     {
                         opts.Add(new FloatMenuOption("KB_Go_To_Sleep_Cannot_Sleep".Translate() + ": " + "NoPath".Translate().CapitalizeFirst(), null));
+                    }
+                    else if (!(bedBuilding is null) && pawn.BodySize > bedBuilding.def.building.bed_maxBodySize)
+                    {
+                        opts.Add(new FloatMenuOption("KB_Go_To_Sleep_Cannot_Sleep".Translate() + ": " + "KB_Go_To_Sleep_Bed_Too_Small".Translate().CapitalizeFirst(), null));
                     }
                     else
                     {


### PR DESCRIPTION
This is not really a relevant situation in vanilla, as the ways to modify a pawn's body size are limited, and non-animal beds do not limit pawns by body size. However, it can come into play with mods that allow increasing body size greatly, and other mods that limit the body size a bed can hold.

Example mods: [Big and Small Races](https://steamcommunity.com/sharedfiles/filedetails/?id=2894397737) adds, for example, Jotun xenotypes, with body sizes > 3.0, and the related [Big and Small Furniture](https://steamcommunity.com/sharedfiles/filedetails/?id=3024478368) mod makes normal beds accept pawn sizes up to 1.9.